### PR TITLE
I ran into to issues when running the script:

### DIFF
--- a/openioc_scan.py
+++ b/openioc_scan.py
@@ -1289,7 +1289,11 @@ class DriverItem(impscan.ImpScan, devicetree.DriverIrp, callbacks.Callbacks, tim
                 signaled = "-"
             due_time = "{0:#010x}:{1:#010x}".format(timer.DueTime.HighPart, timer.DueTime.LowPart)
             #records.append((module.DllBase.v(), timer.obj_offset, due_time, timer.Period.v(), signaled, timer.Dpc.DeferredRoutine.v()))
-            records.append((str(module.DllBase.v()), str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
+#Quickfix for module=None
+	    if module is None:
+            	records.append(('None', str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
+            else:
+            	records.append((str(module.DllBase.v()), str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
 
         if len(records) == 0:
             records.append(('dummy', 'dummy', 'dummy', 'dummy', 'dummy', 'dummy')) # insert dummy for done
@@ -1419,6 +1423,7 @@ class FileItem(mftparser.MFTParser):
             for a, i in attributes:
                 size = -1
                 if a.startswith("FILE_NAME"):
+		    debug.debug(a)
                     if hasattr(i, "ParentDirectory"):
                         name = mft_entry.remove_unprintable(i.get_name()) or "(Null)"
                         if len(name.split('.')) > 1:
@@ -1428,8 +1433,8 @@ class FileItem(mftparser.MFTParser):
                         full = mft_entry.get_full_path(i)
                         #size = int(i.RealFileSize)
                         size = str(i.RealFileSize.v())
-                        debug.debug('NTFS file info from MFT entry $FN: name={0}, ext={1}, full={2}'.format(name, ext, full))
-                        records.append((offset, mft_entry.RecordNumber.v(), name, ext, full, size))
+                        #records.append((offset, mft_entry.RecordNumber.v(), name, ext, full, size))
+                        records.append((offset, mft_entry.RecordNumber.v(), unicode(name), unicode(ext), unicode(full), unicode(size)))
 
         if len(records) == 0:
             records.append((0, 0, 'dummy', 'dummy', 'dummy', 0)) # insert dummy for done


### PR DESCRIPTION
Thing 1:

  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/volatility/plugins/openioc_scan.py", line 1436, in extract_MFT_entries
    self.cur.executemany("insert or ignore into files values (?, ?, ?, ?, ?, ?)", records)
sqlite3.ProgrammingError: You must not use 8-bit bytestrings unless you use a text_factory that can interpret 8-bit bytestrings (like text_factory = str). It is highly recommended that you instead just switch your application to Unicode strings.

Thing 2:

  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/volatility/plugins/openioc_scan.py", line 1292, in extract_timers
    records.append((str(module.DllBase.v()), str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
AttributeError: 'NoneType' object has no attribute 'DllBase'

These changes fix them (albeit maybe not in the nicest way):
## <             records.append((str(module.DllBase.v()), str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))

> # Quickfix for module=None
> 
> ```
>   if module is None:
>           records.append(('None', str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
>         else:
>           records.append((str(module.DllBase.v()), str(timer.obj_offset), due_time, timer.Period.v(), signaled, str(timer.Dpc.DeferredRoutine.v())))
> ```
> 
> 1421a1426
>           debug.debug(a)
> 1431,1432c1436,1437
> <                         debug.debug('NTFS file info from MFT entry $FN: name={0}, ext={1}, full={2}'.format(name, ext, full))
> ## <                         records.append((offset, mft_entry.RecordNumber.v(), name, ext, full, size))
> 
> ```
>                     #records.append((offset, mft_entry.RecordNumber.v(), name, ext, full, size))
>                     records.append((offset, mft_entry.RecordNumber.v(), unicode(name), unicode(ext), unicode(full), unicode(size)))
> ```
